### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -72,7 +72,7 @@ The templates are available in the "Documentation/File Templates/" folder.
 
 Copy the "File Templates/" directory into your "~/Library/Developer/Xcode/Templates/" directory to get ready using these templates.
 
-If you're using cocoa pods, File templates are automatically installed when executing the <pre>pod update</pre> command line.
+If you're using CocoaPods, File templates are automatically installed when executing the <pre>pod update</pre> command line.
 
 ### Code Snippets
 
@@ -85,7 +85,7 @@ Code snipers are available in the "Documentation/CodeSnippets/" folder.
 
 Copy the "CodeSnippets/" directory into your "~/Library/Developer/Xcode/UserData/CodeSnippets/" directory to get ready using these snippets.
 
-If you're using cocoa pods, Code snippets are automatically installed when executing the <pre>pod update</pre> command line.
+If you're using CocoaPods, Code snippets are automatically installed when executing the <pre>pod update</pre> command line.
 
 ## Installation
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
